### PR TITLE
removed reason for why conformal prediction filter not used in production

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -178,8 +178,7 @@ FLOSS enthusiast.
       a credit bureau.
       Able to pre-reject 17\% of all rejected requests while
       maintaining an accuracy of 98\%.
-      Currently not applied in production due to a policy shift of the
-      bank in wake of the COVID-19 pandemic.
+      Currently not applied in production.
   \end{itemize}
 
 \item \textbf{Sep 2018 -- Jul 2019: Working Student, RLE International.}


### PR DESCRIPTION
Fixes #28.